### PR TITLE
Add sort_on DSL for custom orderings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,38 @@ Property.sort(addresses: {id: {asc: :nulls_frist}}).to_sql
 # => "...INNER JOIN addresses ON addresses.property_id = properties.id
 # => "   ORDER BY addresses.id ASC NULLS FIRST"
 ```
+
+Custom Sorts
+------------
+
+Declare named sorts on a model with `sort_on`. The block is evaluated against
+the relation and receives the options passed to `sort`, letting you build any
+ordering expression you want. An optional second argument pre-applies joins
+that the sort depends on.
+
+```ruby
+class Property < ActiveRecord::Base
+  has_many :addresses
+
+  sort_on(:by_name) { |options| order(name: options || :asc) }
+
+  sort_on(:by_address_count, :addresses) do |options|
+    direction = options.is_a?(Hash) ? options.keys.first : options
+    order(Arel.sql("COUNT(addresses.id) #{direction || 'ASC'}")).group('properties.id')
+  end
+end
+
+Property.sort(:by_name)
+# => "...ORDER BY properties.name ASC"
+
+Property.sort(by_name: :desc)
+# => "...ORDER BY properties.name DESC"
+
+Property.sort(by_address_count: :desc)
+# => "...INNER JOIN addresses ON addresses.property_id = properties.id
+# => "   GROUP BY properties.id
+# => "   ORDER BY COUNT(addresses.id) DESC"
+```
+
+Custom sorts take precedence over matching column and relation names, so they
+can also be used to override the default behavior for a given key.

--- a/ext/active_record/base.rb
+++ b/ext/active_record/base.rb
@@ -23,7 +23,9 @@ module ActiveRecord
       ordering.each do |order|
         order = Array(order)
         order.each do |column_or_relation, options|
-          if column_or_relation.to_sym == :random
+          if custom = self.sorts[column_or_relation.to_s]
+            resource = resource.sort_for_custom(custom, options)
+          elsif column_or_relation.to_sym == :random
             resource = resource.random_sort
           elsif self.column_names.include?(column_or_relation.to_s)
             resource = resource.sort_for_column(self.arel_table[column_or_relation.to_s], options)
@@ -44,6 +46,15 @@ module ActiveRecord
     
     def random_sort
       self.order(Arel::Nodes::RandomOrdering.new)
+    end
+
+    def sort_for_custom(custom, options)
+      resource = self
+      if custom[:joins]
+        resource = resource.joins(custom[:joins])
+      end
+      result = resource.instance_exec(options, &custom[:block])
+      result.is_a?(ActiveRecord::Relation) ? result : resource
     end
 
     # TODO: probably don't need to cast to sym

--- a/lib/active_record/sort.rb
+++ b/lib/active_record/sort.rb
@@ -3,4 +3,22 @@ require 'arel/extensions'
 
 require File.expand_path(File.join(__FILE__, '../../../ext/active_record/base'))
 
+module ActiveRecord::Sort
+
+  def inherited(subclass)
+    super
+    subclass.instance_variable_set('@sorts', HashWithIndifferentAccess.new)
+  end
+
+  def sorts
+    @sorts ||= HashWithIndifferentAccess.new
+  end
+
+  def sort_on(name, dependent_joins = nil, &block)
+    sorts[name.to_s] = { joins: dependent_joins, block: block }
+  end
+
+end
+
+ActiveRecord::Base.extend(ActiveRecord::Sort)
 ActiveRecord::Querying.delegate :sort, to: :all

--- a/test/database.rb
+++ b/test/database.rb
@@ -34,6 +34,14 @@ class Property < ActiveRecord::Base
 
   has_many :addresses
 
+  sort_on(:by_name) { |options| order(name: options || :asc) }
+
+  sort_on(:by_address_count, :addresses) do |options|
+    direction = options.is_a?(Hash) ? options.keys.first : options
+    direction ||= :asc
+    order(Arel.sql("COUNT(\"addresses\".\"id\") #{direction.to_s.upcase}")).group('"properties"."id"')
+  end
+
 end
 
 

--- a/test/sort_custom_test.rb
+++ b/test/sort_custom_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class SortCustomTest < ActiveSupport::TestCase
+
+  class Listing < ActiveRecord::Base
+    self.table_name = 'properties'
+    sort_on(:id) { |_options| order(id: :desc) }
+  end
+
+  test '::sort_on registers a custom sort' do
+    assert Property.sorts.key?(:by_name)
+  end
+
+  test '::sort(:custom_sort)' do
+    assert_equal(
+      'SELECT "properties".* FROM "properties" ORDER BY "properties"."name" ASC',
+      Property.sort(:by_name).to_sql.gsub(/\s+/, ' ')
+    )
+  end
+
+  test '::sort(:custom_sort => :desc)' do
+    assert_equal(
+      'SELECT "properties".* FROM "properties" ORDER BY "properties"."name" DESC',
+      Property.sort(:by_name => :desc).to_sql.gsub(/\s+/, ' ')
+    )
+  end
+
+  test '::sort(:custom_sort) applies dependent joins' do
+    sql = Property.sort(:by_address_count => :desc).to_sql.gsub(/\s+/, ' ')
+    assert_includes sql, 'INNER JOIN "addresses"'
+    assert_includes sql, 'COUNT("addresses"."id") DESC'
+    assert_includes sql, 'GROUP BY "properties"."id"'
+  end
+
+  test '::sort_on can override an existing column' do
+    assert_equal(
+      'SELECT "properties".* FROM "properties" ORDER BY "properties"."id" DESC',
+      Listing.sort(:id).to_sql.gsub(/\s+/, ' ')
+    )
+  end
+
+  test '::sort raises for unknown sort' do
+    assert_raises(ActiveRecord::StatementInvalid) do
+      Property.sort(:does_not_exist)
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary
- New `sort_on(name, dependent_joins = nil, &block)` class method that registers a named custom sort, mirroring `activerecord-filter`'s `filter_on`
- `sort(:name)` / `sort(name: :desc)` dispatches to the registered block; the block is `instance_exec`'d against the relation and receives the options verbatim (direction symbol, `{asc: :nulls_last}` hash, etc.) so it can build any ordering expression
- Custom sorts are checked before columns and relations, so they can also override the default behavior for a given key
- `dependent_joins` is applied via `joins(...)` before the block runs

## Example

```ruby
class Property < ActiveRecord::Base
  has_many :addresses

  sort_on(:by_name) { |dir| order(name: dir || :asc) }

  sort_on(:by_address_count, :addresses) do |dir|
    direction = dir.is_a?(Hash) ? dir.keys.first : dir
    order(Arel.sql("COUNT(addresses.id) #{direction || 'ASC'}")).group('properties.id')
  end
end

Property.sort(by_address_count: :desc)
```

## Test plan
- [x] `bundle exec rake test` — 26 tests, 31 assertions, 0 failures (6 new cases in `test/sort_custom_test.rb` covering basic custom sort, direction, dependent joins, column override, and unknown-key raising)
- [ ] CI matrix (Rails 7.1/7.2/8.0/8.1 × Ruby 3.3/3.4/4.0-preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)